### PR TITLE
add aws_region variable, defaulting to eu-west-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ module "example_sns_topic" {
 |------|-------------|:----:|:-----:|:-----:|
 | team_name |  | string | - | yes |
 | topic_display_name | The display name of your SNS Topic. MUST BE UNDER 10 CHARS | string | - | yes |
+| aws_region | Region (ex: eu-west-2) | string | eu-west-2 | no |
+
 
 ## Outputs
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -17,6 +17,7 @@ module "example_sns_topic" {
 
   team_name          = "example-team"
   topic_display_name = "example-topic-display-name"
+  aws_region         = "eu-west-2"
 }
 
 resource "kubernetes_secret" "example_sns_topic" {

--- a/example/main.tf
+++ b/example/main.tf
@@ -13,7 +13,7 @@ provider "aws" {
  *
  */
 module "example_sns_topic" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=2.0"
 
   team_name          = "example-team"
   topic_display_name = "example-topic-display-name"

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,8 @@
+provider "aws" {
+  alias  = "london"
+  region = "${var.aws_region}"
+}
+
 resource "random_id" "id" {
   byte_length = 16
 }
@@ -5,6 +10,7 @@ resource "random_id" "id" {
 // SNS topics do not support tagging, however, the name can be up to 256
 // characters so it should be safe to use the team name here for identification.
 resource "aws_sns_topic" "new_topic" {
+  provider     = "aws.london"
   name         = "cloud-platform-${var.team_name}-${random_id.id.hex}"
   display_name = "${var.topic_display_name}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -5,3 +5,8 @@ variable "topic_display_name" {
 variable "team_name" {
   description = "The name of your team"
 }
+
+variable "aws_region" {
+  description = "Region into which the resource will be created"
+  default     = "eu-west-2"
+}


### PR DESCRIPTION
- `aws_region` variable

- defaulting to eu-west-2

- updated readme and example