### PR TITLE
Module upgrade to terraform 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Terraform module that will create an SNS Topic in AWS, along with an IAM User to
 
 ```hcl
 module "example_sns_topic" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns?ref=3.0"
 
   team_name          = "example-repo"
   topic_display_name = "example-topic-display-name"

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   alias  = "london"
-  region = "${var.aws_region}"
+  region = var.aws_region
 }
 
 resource "random_id" "id" {
@@ -10,9 +10,9 @@ resource "random_id" "id" {
 // SNS topics do not support tagging, however, the name can be up to 256
 // characters so it should be safe to use the team name here for identification.
 resource "aws_sns_topic" "new_topic" {
-  provider     = "aws.london"
+  provider     = aws.london
   name         = "cloud-platform-${var.team_name}-${random_id.id.hex}"
-  display_name = "${var.topic_display_name}"
+  display_name = var.topic_display_name
 }
 
 resource "aws_iam_user" "user" {
@@ -21,7 +21,7 @@ resource "aws_iam_user" "user" {
 }
 
 resource "aws_iam_access_key" "user" {
-  user = "${aws_iam_user.user.name}"
+  user = aws_iam_user.user.name
 }
 
 data "aws_iam_policy_document" "policy" {
@@ -56,13 +56,13 @@ data "aws_iam_policy_document" "policy" {
     ]
 
     resources = [
-      "${aws_sns_topic.new_topic.arn}",
+      aws_sns_topic.new_topic.arn,
     ]
   }
 }
 
 resource "aws_iam_user_policy" "policy" {
   name   = "sns-topic"
-  policy = "${data.aws_iam_policy_document.policy.json}"
-  user   = "${aws_iam_user.user.name}"
+  policy = data.aws_iam_policy_document.policy.json
+  user   = aws_iam_user.user.name
 }

--- a/output.tf
+++ b/output.tf
@@ -1,24 +1,24 @@
 output "user_name" {
   description = "IAM user with access to the topic"
-  value       = "${aws_iam_user.user.name}"
+  value       = aws_iam_user.user.name
 }
 
 output "topic_name" {
   description = "ARN for the topic"
-  value       = "${aws_sns_topic.new_topic.name}"
+  value       = aws_sns_topic.new_topic.name
 }
 
 output "topic_arn" {
   description = "ARN for the topic"
-  value       = "${aws_sns_topic.new_topic.arn}"
+  value       = aws_sns_topic.new_topic.arn
 }
 
 output "access_key_id" {
   description = "The access key ID"
-  value       = "${aws_iam_access_key.user.id}"
+  value       = aws_iam_access_key.user.id
 }
 
 output "secret_access_key" {
   description = "The secret access key ID"
-  value       = "${aws_iam_access_key.user.secret}"
+  value       = aws_iam_access_key.user.secret
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,12 +1,15 @@
 variable "topic_display_name" {
   description = "The display name of your SNS Topic. MUST BE UNDER 10 CHARS"
+  type        = string
 }
 
 variable "team_name" {
   description = "The name of your team"
+  type        = string
 }
 
 variable "aws_region" {
   description = "Region into which the resource will be created"
   default     = "eu-west-2"
+  type        = string
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Upgraded module to terraform 12 and tested against our CP AWS Account. 

It was also added variables type to variables.tf and updated the README to use a reference in the "Usage" section.

This closes ministryofjustice/cloud-platform#1376