### PR TITLE
remove provider block from sns module

### DIFF
--- a/example/sns.tf
+++ b/example/sns.tf
@@ -5,7 +5,7 @@
  *
  */
 module "example_sns_topic" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic?ref=4.1"
 
   team_name          = "example-team"
   topic_display_name = "example-topic-display-name"

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,3 @@
-provider "aws" {
-  alias  = "london"
-  region = var.aws_region
-}
-
 resource "random_id" "id" {
   byte_length = 16
 }
@@ -10,7 +5,6 @@ resource "random_id" "id" {
 // SNS topics do not support tagging, however, the name can be up to 256
 // characters so it should be safe to use the team name here for identification.
 resource "aws_sns_topic" "new_topic" {
-  provider     = aws.london
   name         = "cloud-platform-${var.team_name}-${random_id.id.hex}"
   display_name = var.topic_display_name
 }


### PR DESCRIPTION
This PR gets rid of a legacy provider definition within the SNS topic module.
The example is already up-to-date.

This would be the release v4.1

Tested.