### PR TITLE
Add support for additional IAM users per-topic

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "user_name" {
   description = "IAM user with access to the topic"
-  value       = aws_iam_user.user.name
+  value       = aws_iam_user.user[var.team_name].name
 }
 
 output "topic_name" {
@@ -15,10 +15,18 @@ output "topic_arn" {
 
 output "access_key_id" {
   description = "The access key ID"
-  value       = aws_iam_access_key.user.id
+  value       = aws_iam_access_key.user[var.team_name].id
 }
 
 output "secret_access_key" {
   description = "The secret access key ID"
-  value       = aws_iam_access_key.user.secret
+  value       = aws_iam_access_key.user[var.team_name].secret
+}
+
+output "access_keys" {
+  description = "The list of access keys for all teams"
+  value = [for key in aws_iam_access_key.user : {
+    id     = key.id,
+    secret = key.secret
+  }]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,12 @@ variable "team_name" {
   type        = string
 }
 
+variable "additional_team_names" {
+  description = "A list of additional team names that require access to the topic. A dedicated IAM user and access keywill be created for each team."
+  type        = list(string)
+  default     = []
+}
+
 variable "environment_name" {
   description = "Environment name"
   type        = string


### PR DESCRIPTION
This is so we can have isolated access keys per team.

The idea is we could use this like so:
```hcl
module "shared_topic" {
  source = "github.com/ministryofjustice/cloud-platform-terraform-sns-topic"
  // ...
  team_name              = var.team_name
  additional_team_names  = ["team1", "team2", "team3"]
}

resource "kubernetes_secret" "team1_secret" {
  data = {
    access_key_id     = module.shared_topic.access_keys["team1"].id
    secret_access_key = module.shared_topic.access_keys["team1"].secret
    topic_arn         = module.shared_topic.topic_arn
  }
}

resource "kubernetes_secret" "team2_secret" {
  data = {
    access_key_id     = module.shared_topic.access_keys["team2"].id
    secret_access_key = module.shared_topic.access_keys["team2"].secret
    topic_arn         = module.shared_topic.topic_arn
  }
}

// ..etc
```