### PR TITLE
Iam users

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,16 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_iam_access_key.additional_users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key) | resource |
 | [aws_iam_access_key.user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key) | resource |
+| [aws_iam_user.additional_users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user.user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
+| [aws_iam_user_policy.additional_users_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
 | [aws_iam_user_policy.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
 | [aws_kms_alias.alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_sns_topic.new_topic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [random_id.additional_user_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_id.id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -71,6 +75,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_additional_team_names"></a> [additional\_team\_names](#input\_additional\_team\_names) | A list of additional team names that require access to the topic. A dedicated IAM user and access key will be created for each team. | `list` | `[]` | no |
 | <a name="input_application"></a> [application](#input\_application) | Application name | `string` | n/a | yes |
 | <a name="input_business_unit"></a> [business\_unit](#input\_business\_unit) | Area of the MOJ responsible for the service | `string` | n/a | yes |
 | <a name="input_encrypt_sns_kms"></a> [encrypt\_sns\_kms](#input\_encrypt\_sns\_kms) | If set to true, this will create aws\_kms\_key and aws\_kms\_alias resources and add kms\_master\_key\_id in aws\_sns\_topic resource | `bool` | `false` | no |
@@ -86,6 +91,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_access_key_id"></a> [access\_key\_id](#output\_access\_key\_id) | The access key ID |
+| <a name="output_additional_access_keys"></a> [additional\_access\_keys](#output\_additional\_access\_keys) | The list of access keys for additional teams |
 | <a name="output_secret_access_key"></a> [secret\_access\_key](#output\_secret\_access\_key) | The secret access key ID |
 | <a name="output_topic_arn"></a> [topic\_arn](#output\_topic\_arn) | ARN for the topic |
 | <a name="output_topic_name"></a> [topic\_name](#output\_topic\_name) | ARN for the topic |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_additional_team_names"></a> [additional\_team\_names](#input\_additional\_team\_names) | A list of additional team names that require access to the topic. A dedicated IAM user and access key will be created for each team. | `list` | `[]` | no |
+| <a name="input_additional_topic_clients"></a> [additional\_topic\_clients](#input\_additional\_topic\_clients) | A list of additional clients that require access to the topic. A dedicated IAM user and access key will be created for each client. | `list` | `[]` | no |
 | <a name="input_application"></a> [application](#input\_application) | Application name | `string` | n/a | yes |
 | <a name="input_business_unit"></a> [business\_unit](#input\_business\_unit) | Area of the MOJ responsible for the service | `string` | n/a | yes |
 | <a name="input_encrypt_sns_kms"></a> [encrypt\_sns\_kms](#input\_encrypt\_sns\_kms) | If set to true, this will create aws\_kms\_key and aws\_kms\_alias resources and add kms\_master\_key\_id in aws\_sns\_topic resource | `bool` | `false` | no |

--- a/example/sns.tf
+++ b/example/sns.tf
@@ -16,10 +16,10 @@ module "example_sns_topic" {
   infrastructure_support = "example"
   namespace              = "example"
 
-  # Uncomment additional_team_names and populate list for provisioning additional IAM user/access keys for topic access
+  # Uncomment additional_topic_clients and populate list for provisioning additional IAM user/access keys for topic access
   # via other namespaces - see kubernetes_secret examples below
   #
-  # additional_team_names = [ "team-1","team-2" ]
+  # additional_topic_clients = [ "team-1","team-2" ]
   providers = {
     aws = aws.london
   }
@@ -49,6 +49,22 @@ resource "kubernetes_secret" "example_sns_topic" {
 #   data = {
 #     access_key_id     = module.sw_sns.additional_access_keys["team-1"].access_key_id
 #     secret_access_key = module.sw_sns.additional_access_keys["team-1"].secret_access_key
+#     topic_arn         = module.sw_sns.topic_arn
+#   }
+# }
+
+# Or, define your additional_topic_clients as target namespace strings and iterate over the list with a single kubernetes secret:
+# 
+# resource "kubernetes_secret" "additional_secrets" {
+#   for_each = toset(var.additional_topic_clients)
+#   metadata {
+#     name      = "sns-topic-sns-client-${each.value}"
+#     namespace = each.value
+#   }
+
+#   data = {
+#     access_key_id     = module.sw_sns.additional_access_keys[each.value].access_key_id
+#     secret_access_key = module.sw_sns.additional_access_keys[each.value].secret_access_key
 #     topic_arn         = module.sw_sns.topic_arn
 #   }
 # }

--- a/example/sns.tf
+++ b/example/sns.tf
@@ -16,6 +16,10 @@ module "example_sns_topic" {
   infrastructure_support = "example"
   namespace              = "example"
 
+  # Uncomment additional_team_names and populate list for provisioning additional IAM user/access keys for topic access
+  # via other namespaces - see kubernetes_secret examples below
+  #
+  # additional_team_names = [ "team-1","team-2" ]
   providers = {
     aws = aws.london
   }
@@ -34,3 +38,17 @@ resource "kubernetes_secret" "example_sns_topic" {
   }
 }
 
+# Example for pushing additional user/access key secrets into namespaces 
+#
+# resource "kubernetes_secret" "team_1_secret" {
+#   metadata {
+#     name      = "sns-topic-sns-user"
+#     namespace = "another-namespace"
+#   }
+
+#   data = {
+#     access_key_id     = module.sw_sns.additional_access_keys["team-1"].access_key_id
+#     secret_access_key = module.sw_sns.additional_access_keys["team-1"].secret_access_key
+#     topic_arn         = module.sw_sns.topic_arn
+#   }
+# }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  additional_teams = toset(var.additional_teams)
+  additional_teams = toset(var.additional_team_names)
 }
 resource "random_id" "id" {
   byte_length = 16

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,8 @@
 data "aws_caller_identity" "current" {}
 
+locals {
+  additional_teams = toset(var.additional_teams)
+}
 resource "random_id" "id" {
   byte_length = 16
 }
@@ -147,23 +150,23 @@ resource "aws_iam_user_policy" "policy" {
 }
 
 resource "random_id" "user_id" {
-  for_each    = var.additional_team_names
+  for_each    = local.additional_teams
   byte_length = 16
 }
 
 resource "aws_iam_user" "additional_users" {
-  for_each = var.additional_team_names
+  for_each = local.additional_teams
   name     = "cp-sns-topic-${random_id.user_id[each.value].hex}"
   path     = "/system/sns-topic-user/${each.value}/"
 }
 
 resource "aws_iam_access_key" "additional_users" {
-  for_each = var.additional_team_names
+  for_each = local.additional_teams
   user     = aws_iam_user.additional_users[each.value].name
 }
 
 resource "aws_iam_user_policy" "additional_users_policy" {
-  for_each = var.additional_team_names
+  for_each = local.additional_teams
   name     = "sns-topic"
   policy   = data.aws_iam_policy_document.policy.json
   user     = aws_iam_user.user[each.value].name

--- a/main.tf
+++ b/main.tf
@@ -169,5 +169,5 @@ resource "aws_iam_user_policy" "additional_users_policy" {
   for_each = local.additional_teams
   name     = "sns-topic"
   policy   = data.aws_iam_policy_document.policy.json
-  user     = aws_iam_user.user[each.value].name
+  user     = aws_iam_user.additional_users[each.value].name
 }

--- a/main.tf
+++ b/main.tf
@@ -149,14 +149,14 @@ resource "aws_iam_user_policy" "policy" {
   user   = aws_iam_user.user.name
 }
 
-resource "random_id" "user_id" {
+resource "random_id" "additional_user_id" {
   for_each    = local.additional_teams
   byte_length = 16
 }
 
 resource "aws_iam_user" "additional_users" {
   for_each = local.additional_teams
-  name     = "cp-sns-topic-${random_id.user_id[each.value].hex}"
+  name     = "cp-sns-topic-${random_id.additional_user_id[each.value].hex}"
   path     = "/system/sns-topic-user/${each.value}/"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  additional_teams = toset(var.additional_team_names)
+  additional_clients = toset(var.additional_topic_clients)
 }
 resource "random_id" "id" {
   byte_length = 16
@@ -150,23 +150,23 @@ resource "aws_iam_user_policy" "policy" {
 }
 
 resource "random_id" "additional_user_id" {
-  for_each    = local.additional_teams
+  for_each    = local.additional_clients
   byte_length = 16
 }
 
 resource "aws_iam_user" "additional_users" {
-  for_each = local.additional_teams
+  for_each = local.additional_clients
   name     = "cp-sns-topic-${random_id.additional_user_id[each.value].hex}"
   path     = "/system/sns-topic-user/${each.value}/"
 }
 
 resource "aws_iam_access_key" "additional_users" {
-  for_each = local.additional_teams
+  for_each = local.additional_clients
   user     = aws_iam_user.additional_users[each.value].name
 }
 
 resource "aws_iam_user_policy" "additional_users_policy" {
-  for_each = local.additional_teams
+  for_each = local.additional_clients
   name     = "sns-topic"
   policy   = data.aws_iam_policy_document.policy.json
   user     = aws_iam_user.additional_users[each.value].name

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,15 @@
 data "aws_caller_identity" "current" {}
 
+locals {
+  team_names = toset(concat([var.team_name], var.additional_team_names))
+}
 resource "random_id" "id" {
+  for_each    = local.team_names
   byte_length = 16
 }
 
 resource "aws_kms_key" "kms" {
-  description = "KMS key for cloud-platform-${var.team_name}-${random_id.id.hex}"
+  description = "KMS key for cloud-platform-${var.team_name}-${random_id.id[var.team_name].hex}"
   count       = var.encrypt_sns_kms ? 1 : 0
 
   policy = <<EOF
@@ -71,7 +75,7 @@ EOF
 
 resource "aws_kms_alias" "alias" {
   count         = var.encrypt_sns_kms ? 1 : 0
-  name          = "alias/cloud-platform-${var.team_name}-${random_id.id.hex}"
+  name          = "alias/cloud-platform-${var.team_name}-${random_id.id[var.team_name].hex}"
   target_key_id = aws_kms_key.kms[0].key_id
 }
 
@@ -79,7 +83,7 @@ resource "aws_kms_alias" "alias" {
 # the team name for identification purposes.
 # Tagging was added to this module on 2022-12-28.
 resource "aws_sns_topic" "new_topic" {
-  name              = "cloud-platform-${var.team_name}-${random_id.id.hex}"
+  name              = "cloud-platform-${var.team_name}-${random_id.id[var.team_name].hex}"
   display_name      = var.topic_display_name
   kms_master_key_id = var.encrypt_sns_kms ? join("", aws_kms_key.kms[*].arn) : ""
 
@@ -95,12 +99,14 @@ resource "aws_sns_topic" "new_topic" {
 }
 
 resource "aws_iam_user" "user" {
-  name = "cp-sns-topic-${random_id.id.hex}"
-  path = "/system/sns-topic-user/${var.team_name}/"
+  for_each = local.team_names
+  name = "cp-sns-topic-${random_id.id[each.value].hex}"
+  path = "/system/sns-topic-user/${each.value}/"
 }
 
 resource "aws_iam_access_key" "user" {
-  user = aws_iam_user.user.name
+  for_each = local.team_names
+  user = aws_iam_user.user[each.value].name
 }
 
 data "aws_iam_policy_document" "policy" {
@@ -141,7 +147,8 @@ data "aws_iam_policy_document" "policy" {
 }
 
 resource "aws_iam_user_policy" "policy" {
+  for_each = local.team_names
   name   = "sns-topic"
   policy = data.aws_iam_policy_document.policy.json
-  user   = aws_iam_user.user.name
+  user   = aws_iam_user.user[each.value].name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "user_name" {
   description = "IAM user with access to the topic"
-  value       = aws_iam_user.user.name
+  value       = aws_iam_user.user[var.team_name].name
 }
 
 output "topic_name" {
@@ -15,10 +15,18 @@ output "topic_arn" {
 
 output "access_key_id" {
   description = "The access key ID"
-  value       = aws_iam_access_key.user.id
+  value       = aws_iam_access_key.user[var.team_name].id
 }
 
 output "secret_access_key" {
   description = "The secret access key ID"
-  value       = aws_iam_access_key.user.secret
+  value       = aws_iam_access_key.user[var.team_name].secret
+}
+
+output "access_keys" {
+  description = "The list of access keys for all teams"
+  value = [for key in aws_iam_access_key.user : {
+    id = key.id,
+    secret = key.secret
+  }]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "user_name" {
   description = "IAM user with access to the topic"
-  value       = aws_iam_user.user[var.team_name].name
+  value       = aws_iam_user.user.name
 }
 
 output "topic_name" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -26,7 +26,7 @@ output "secret_access_key" {
 output "additional_access_keys" {
   description = "The list of access keys for additional teams"
   value = {
-    for team in var.additional_team_names : team => {
+    for team in var.additional_topic_clients : team => {
       user_name         = aws_iam_user.additional_users[team].name
       access_key_id     = aws_iam_access_key.additional_users[team].id
       secret_access_key = aws_iam_access_key.additional_users[team].secret

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,18 +15,21 @@ output "topic_arn" {
 
 output "access_key_id" {
   description = "The access key ID"
-  value       = aws_iam_access_key.user[var.team_name].id
+  value       = aws_iam_access_key.user.id
 }
 
 output "secret_access_key" {
   description = "The secret access key ID"
-  value       = aws_iam_access_key.user[var.team_name].secret
+  value       = aws_iam_access_key.user.secret
 }
 
-output "access_keys" {
-  description = "The list of access keys for all teams"
-  value = [for key in aws_iam_access_key.user : {
-    id = key.id,
-    secret = key.secret
-  }]
+output "additional_access_keys" {
+  description = "The list of access keys for additional teams"
+  value = {
+    for team in var.additional_team_names : team => {
+      user_name         = aws_iam_user.additional_users[team].name
+      access_key_id     = aws_iam_access_key.additional_users[team].id
+      secret_access_key = aws_iam_access_key.additional_users[team].secret
+    }
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -26,10 +26,10 @@ output "secret_access_key" {
 output "additional_access_keys" {
   description = "The list of access keys for additional teams"
   value = {
-    for team in var.additional_topic_clients : team => {
-      user_name         = aws_iam_user.additional_users[team].name
-      access_key_id     = aws_iam_access_key.additional_users[team].id
-      secret_access_key = aws_iam_access_key.additional_users[team].secret
+    for client in var.additional_topic_clients : client => {
+      user_name         = aws_iam_user.additional_users[client].name
+      access_key_id     = aws_iam_access_key.additional_users[client].id
+      secret_access_key = aws_iam_access_key.additional_users[client].secret
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -49,5 +49,5 @@ variable "namespace" {
 
 variable "additional_team_names" {
   description = "A list of additional team names that require access to the topic. A dedicated IAM user and access key will be created for each team."
-  default = ""
+  default = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -49,4 +49,5 @@ variable "namespace" {
 
 variable "additional_team_names" {
   description = "A list of additional team names that require access to the topic. A dedicated IAM user and access key will be created for each team."
+  default = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -46,3 +46,7 @@ variable "namespace" {
   description = "Namespace name"
   type        = string
 }
+
+variable "additional_team_names" {
+  description = "A list of additional team names that require access to the topic. A dedicated IAM user and access key will be created for each team."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -49,5 +49,5 @@ variable "namespace" {
 
 variable "additional_team_names" {
   description = "A list of additional team names that require access to the topic. A dedicated IAM user and access key will be created for each team."
-  default = []
+  default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -47,7 +47,7 @@ variable "namespace" {
   type        = string
 }
 
-variable "additional_team_names" {
-  description = "A list of additional team names that require access to the topic. A dedicated IAM user and access key will be created for each team."
+variable "additional_topic_clients" {
+  description = "A list of additional clients that require access to the topic. A dedicated IAM user and access key will be created for each client."
   default     = []
 }


### PR DESCRIPTION
This PR enables the creation of additional unique IAM user/key and associated `kubernetes_secret` resources to support the scenario where an sns topic is consumed by multiple clients.

As per support issue:
https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/gh/ministryofjustice/cloud-platform/4383

Example usage

```
module "sns_topic" {
  ...
  additional_topic_clients = [ "team-1","team-2" ]
}

resource "kubernetes_secret" "team_1_secret" {
   metadata {
     name = "sns-topic-sns-user"
     namespace = "another-namespace"
   }

   data = {
     access_key_id  = module.sw_sns.additional_access_keys["team-1"].access_key_id
     secret_access_key = module.sw_sns.additional_access_keys["team-1"].secret_access_key
     topic_arn = module.sw_sns.topic_arn
   }
 }