### PR TITLE
Remove access keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,27 +64,18 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_iam_access_key.additional_users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key) | resource |
-| [aws_iam_access_key.user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key) | resource |
 | [aws_iam_policy.irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_user.additional_users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
-| [aws_iam_user.user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
-| [aws_iam_user_policy.additional_users_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
-| [aws_iam_user_policy.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
 | [aws_kms_alias.alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_sns_topic.new_topic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
-| [random_id.additional_user_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_id.id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_additional_topic_clients"></a> [additional\_topic\_clients](#input\_additional\_topic\_clients) | A list of additional clients that require access to the topic. A dedicated IAM user and access key will be created for each client. | `list` | `[]` | no |
 | <a name="input_application"></a> [application](#input\_application) | Application name | `string` | n/a | yes |
 | <a name="input_business_unit"></a> [business\_unit](#input\_business\_unit) | Area of the MOJ responsible for the service | `string` | n/a | yes |
 | <a name="input_encrypt_sns_kms"></a> [encrypt\_sns\_kms](#input\_encrypt\_sns\_kms) | If set to true, this will create aws\_kms\_key and aws\_kms\_alias resources and add kms\_master\_key\_id in aws\_sns\_topic resource | `bool` | `false` | no |
@@ -99,13 +90,9 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_access_key_id"></a> [access\_key\_id](#output\_access\_key\_id) | The access key ID |
-| <a name="output_additional_access_keys"></a> [additional\_access\_keys](#output\_additional\_access\_keys) | The list of access keys for additional teams |
 | <a name="output_irsa_policy_arn"></a> [irsa\_policy\_arn](#output\_irsa\_policy\_arn) | IAM policy ARN for access to the SNS topic |
-| <a name="output_secret_access_key"></a> [secret\_access\_key](#output\_secret\_access\_key) | The secret access key ID |
 | <a name="output_topic_arn"></a> [topic\_arn](#output\_topic\_arn) | ARN for the topic |
 | <a name="output_topic_name"></a> [topic\_name](#output\_topic\_name) | ARN for the topic |
-| <a name="output_user_name"></a> [user\_name](#output\_user\_name) | IAM user with access to the topic |
 <!-- END_TF_DOCS -->
 
 ## Tags

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,6 @@
 locals {
   # Generic configuration
-  identifier         = "cloud-platform-${var.team_name}-${random_id.id.hex}"
-  additional_clients = toset(var.additional_topic_clients)
+  identifier = "cloud-platform-${var.team_name}-${random_id.id.hex}"
 
   # Tags
   default_tags = {
@@ -114,82 +113,6 @@ resource "aws_sns_topic" "new_topic" {
   kms_master_key_id = var.encrypt_sns_kms ? aws_kms_key.kms[0].arn : null
 
   tags = local.default_tags
-}
-
-# Legacy long-lived credentials
-resource "aws_iam_user" "user" {
-  name = "cp-sns-topic-${random_id.id.hex}"
-  path = "/system/sns-topic-user/${var.team_name}/"
-}
-
-resource "aws_iam_access_key" "user" {
-  user = aws_iam_user.user.name
-}
-
-data "aws_iam_policy_document" "policy" {
-  statement {
-    actions = [
-      "sns:ListEndpointsByPlatformApplication",
-      "sns:ListPlatformApplications",
-      "sns:ListSubscriptions",
-      "sns:ListSubscriptionsByTopic",
-      "sns:ListTopics",
-      "sns:CheckIfPhoneNumberIsOptedOut",
-      "sns:GetEndpointAttributes",
-      "sns:GetPlatformApplicationAttributes",
-      "sns:GetSMSAttributes",
-      "sns:GetSubscriptionAttributes",
-      "sns:GetTopicAttributes",
-      "sns:ListPhoneNumbersOptedOut",
-      "sns:ConfirmSubscription",
-      "sns:CreatePlatformApplication",
-      "sns:CreatePlatformEndpoint",
-      "sns:DeleteEndpoint",
-      "sns:DeletePlatformApplication",
-      "sns:OptInPhoneNumber",
-      "sns:Publish",
-      "sns:SetEndpointAttributes",
-      "sns:SetPlatformApplicationAttributes",
-      "sns:SetSMSAttributes",
-      "sns:SetSubscriptionAttributes",
-      "sns:SetTopicAttributes",
-      "sns:Subscribe",
-      "sns:Unsubscribe",
-    ]
-
-    resources = [
-      aws_sns_topic.new_topic.arn,
-    ]
-  }
-}
-
-resource "aws_iam_user_policy" "policy" {
-  name   = "sns-topic"
-  policy = data.aws_iam_policy_document.policy.json
-  user   = aws_iam_user.user.name
-}
-
-resource "random_id" "additional_user_id" {
-  for_each    = local.additional_clients
-  byte_length = 16
-}
-
-resource "aws_iam_user" "additional_users" {
-  for_each = local.additional_clients
-  name     = "cp-sns-topic-${random_id.additional_user_id[each.value].hex}"
-  path     = "/system/sns-topic-user/${each.value}/"
-}
-
-resource "aws_iam_access_key" "additional_users" {
-  for_each = local.additional_clients
-  user     = aws_iam_user.additional_users[each.value].name
-}
-
-resource "aws_iam_user_policy" "additional_users_policy" {
-  for_each = local.additional_clients
-  name     = "sns-topic"
-  policy   = data.aws_iam_policy_document.policy.json
-  user     = aws_iam_user.additional_users[each.value].name
 }
 
 ##############################

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,8 +1,3 @@
-output "user_name" {
-  description = "IAM user with access to the topic"
-  value       = aws_iam_user.user.name
-}
-
 output "topic_name" {
   description = "ARN for the topic"
   value       = aws_sns_topic.new_topic.name
@@ -11,27 +6,6 @@ output "topic_name" {
 output "topic_arn" {
   description = "ARN for the topic"
   value       = aws_sns_topic.new_topic.arn
-}
-
-output "access_key_id" {
-  description = "The access key ID"
-  value       = aws_iam_access_key.user.id
-}
-
-output "secret_access_key" {
-  description = "The secret access key ID"
-  value       = aws_iam_access_key.user.secret
-}
-
-output "additional_access_keys" {
-  description = "The list of access keys for additional teams"
-  value = {
-    for client in var.additional_topic_clients : client => {
-      user_name         = aws_iam_user.additional_users[client].name
-      access_key_id     = aws_iam_access_key.additional_users[client].id
-      secret_access_key = aws_iam_access_key.additional_users[client].secret
-    }
-  }
 }
 
 output "irsa_policy_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -12,11 +12,6 @@ variable "encrypt_sns_kms" {
   default     = false
 }
 
-variable "additional_topic_clients" {
-  description = "A list of additional clients that require access to the topic. A dedicated IAM user and access key will be created for each client."
-  default     = []
-}
-
 ########
 # Tags #
 ########


### PR DESCRIPTION
Related to [Deprecating long-lived credentials for modules](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/deprecating-long-lived-credentials.html) and ministryofjustice/cloud-platform#4546, ministryofjustice/cloud-platform-security-issues#6.